### PR TITLE
Made initializer required to support dependency injection 

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -132,7 +132,7 @@ public class Banner: UIView {
     /// :param: image The image on the left of the banner. Optional. Defaults to nil.
     /// :param: backgroundColor The color of the banner's background view. Defaults to `UIColor.blackColor()`.
     /// :param: didTapBlock An action to be called when the user taps on the banner. Optional. Defaults to `nil`.
-    public init(title: String, subtitle: String, image: UIImage? = nil, backgroundColor: UIColor = UIColor.blackColor(), didTapBlock: (() -> ())? = nil) {
+    public required init(title: String, subtitle: String, image: UIImage? = nil, backgroundColor: UIColor = UIColor.blackColor(), didTapBlock: (() -> ())? = nil) {
         self.didTapBlock = didTapBlock
         self.image = image
         super.init(frame: CGRectZero)


### PR DESCRIPTION
I was unable to use the library with dependency injection because `Banner.Type` has no required initializer.

Please let me know if you can pull this and push a new version of the Pod ASAP, otherwise, I'm going to need to make a private pod for use in my project.

Thanks!
