### PR TITLE
Remove space in name of Test Helpers subspec

### DIFF
--- a/BRYXBanner.podspec
+++ b/BRYXBanner.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
    }
   end
 
-  s.subspec "Test Helpers" do |sp|
+  s.subspec "TestHelpers" do |sp|
     sp.source_files = 'Pod/Test Helpers/**/*'
     sp.dependency 'BRYXBanner/Core'
   end


### PR DESCRIPTION
Spaces in sub spec names are invalid.

https://github.com/CocoaPods/Core/issues/176
