### PR TITLE
Fix for iOS7

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -283,6 +283,7 @@ public class Banner: UIView {
     public override func layoutSubviews() {
       super.layoutSubviews()
       adjustHeightOffset()
+      layoutIfNeeded()
     }
   
     private func adjustHeightOffset() {


### PR DESCRIPTION
When using the banner in iOS7 an additional `layoutIfNeeded()` call is required as iOS7 doesn't handle this internally.

The exception this resolves is:

```
Auto Layout still required after executing -layoutSubviews. Banner's implementation of -layoutSubviews needs to call super.
```
