### PR TITLE
Swift 2.2 new selector style

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -202,8 +202,8 @@ public class Banner: UIView {
     }
     
     private func addGestureRecognizers() {
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: "didTap:"))
-        let swipe = UISwipeGestureRecognizer(target: self, action: "didSwipe:")
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action:#selector(Banner.didTap(_:))))
+        let swipe = UISwipeGestureRecognizer(target: self, action: #selector(Banner.didSwipe(_:)))
         swipe.direction = .Up
         addGestureRecognizer(swipe)
     }


### PR DESCRIPTION
String literals has been deprecated as selectors and will be removed in Swift 3. This pull uses new semantics of `#selector()` instead of string literal convention
