### PR TITLE
Updated selectors for tap and swipe gestures to use new #selector syntax

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -191,8 +191,8 @@ public class Banner: UIView {
     }
     
     private func addGestureRecognizers() {
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: "didTap:"))
-        let swipe = UISwipeGestureRecognizer(target: self, action: "didSwipe:")
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(didTap(_:))))
+        let swipe = UISwipeGestureRecognizer(target: self, action: #selector(didSwipe(_:)))
         swipe.direction = .Up
         addGestureRecognizer(swipe)
     }


### PR DESCRIPTION
These warnings were appearing when I attempted to push a podspec to my private repo:

BRYXBanner/Pod/Classes/Banner.swift:194:75: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead
BRYXBanner/Pod/Classes/Banner.swift:195:68: warning: use of string literal for Objective-C selectors is deprecated; use '#selector' instead

Not sure why Xcode didn't catch these warnings, but CocoaPods did and I fixed them.

-JettF
