### PR TITLE
update selectors for Swift 2.2

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -35,6 +35,14 @@ public enum BannerSpringiness {
     }
 }
 
+/// Banner action selectors
+private extension Selector {
+    
+    static let bannerTapped = #selector(Banner.didTap(_:))
+    static let bannerSwiped = #selector(Banner.didSwipe(_:))
+    
+}
+
 /// Banner is a dropdown notification view that presents above the main view controller, but below the status bar.
 public class Banner: UIView {
     class func topWindow() -> UIWindow? {
@@ -202,8 +210,8 @@ public class Banner: UIView {
     }
     
     private func addGestureRecognizers() {
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: "didTap:"))
-        let swipe = UISwipeGestureRecognizer(target: self, action: "didSwipe:")
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action: .bannerTapped))
+        let swipe = UISwipeGestureRecognizer(target: self, action: .bannerSwiped)
         swipe.direction = .Up
         addGestureRecognizer(swipe)
     }


### PR DESCRIPTION
Updating selectors to Swift 2.2. Using the `Selector` extension pattern suggested by [Andyy Hope](https://medium.com/swift-programming/swift-selector-syntax-sugar-81c8a8b10df3#.58jb4kqn8).
