### PR TITLE
Updated Swift Syntax to Xcode Beta 6 and Fixed Banner Animations on iOS 10

### DIFF
--- a/Example/BRYXBanner/AppDelegate.swift
+++ b/Example/BRYXBanner/AppDelegate.swift
@@ -13,34 +13,33 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey : Any]? = nil) -> Bool {
         // Override point for customization after application launch.
-        application.statusBarStyle = UIStatusBarStyle.LightContent
+        application.statusBarStyle = UIStatusBarStyle.lightContent
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
-
 
 }
 

--- a/Example/BRYXBanner/BorderedButton.swift
+++ b/Example/BRYXBanner/BorderedButton.swift
@@ -25,7 +25,7 @@ class BorderedButton: UIButton {
     
     private var selectionBackgroundColor: UIColor? {
         didSet {
-            self.setTitleColor(selectionBackgroundColor, forState: .Highlighted)
+            self.setTitleColor(selectionBackgroundColor, for: .highlighted)
         }
     }
     
@@ -40,13 +40,13 @@ class BorderedButton: UIButton {
     
     override var tintColor: UIColor! {
         didSet {
-            self.setTitleColor(tintColor, forState: .Normal)
-            self.layer.borderColor = tintColor?.CGColor
+            self.setTitleColor(tintColor, for: UIControlState())
+            self.layer.borderColor = tintColor?.cgColor
         }
     }
     
     init() {
-        super.init(frame: CGRectZero)
+        super.init(frame: CGRect.zero)
         loadView()
     }
     
@@ -60,9 +60,9 @@ class BorderedButton: UIButton {
         loadView()
     }
     
-    convenience init(title: String, tintColor: UIColor? = UIColor.lightGrayColor(), backgroundColor: UIColor? = UIColor.whiteColor()) {
-        self.init(frame: CGRectZero)
-        self.setTitle(title, forState: .Normal)
+    convenience init(title: String, tintColor: UIColor? = UIColor.lightGray, backgroundColor: UIColor? = UIColor.white) {
+        self.init(frame: CGRect.zero)
+        self.setTitle(title, for: UIControlState())
         
         ({ self.tintColor = tintColor }())
         ({ self.backgroundColor = backgroundColor }())
@@ -70,23 +70,23 @@ class BorderedButton: UIButton {
     
     private func loadView() {
         
-        super.backgroundColor = UIColor.clearColor()
+        super.backgroundColor = UIColor.clear
         
-        self.titleLabel?.font = UIFont.boldSystemFontOfSize(15.0)
+        self.titleLabel?.font = UIFont.boldSystemFont(ofSize: 15.0)
         
         self.borderWidth = 1.0
         self.layer.cornerRadius = borderRadius
         if let tint = self.tintColor {
-            self.layer.borderColor = tint.CGColor
+            self.layer.borderColor = tint.cgColor
         }
         
         self.layer.masksToBounds = false
         self.clipsToBounds = false
     }
     
-    override var highlighted: Bool {
+    override var isHighlighted: Bool {
         didSet {
-            if oldValue == self.highlighted { return }
+            if oldValue == self.isHighlighted { return }
             let background = self.backgroundColor
             let tint = self.tintColor
             super.backgroundColor = tint

--- a/Example/BRYXBanner/ViewController.swift
+++ b/Example/BRYXBanner/ViewController.swift
@@ -25,15 +25,15 @@ class ViewController: UIViewController {
     @IBOutlet weak var colorSegmentedControl: UISegmentedControl!
     @IBOutlet weak var inViewSwitch: UISwitch!
     
-    @IBAction func showButtonTapped(sender: UIButton) {
+    @IBAction func showButtonTapped(_ sender: UIButton) {
         let color = currentColor()
-        let image = imageSwitch.on ? UIImage(named: "Icon") : nil
+        let image = imageSwitch.isOn ? UIImage(named: "Icon") : nil
         let title = titleField.text?.validated
         let subtitle = subtitleField.text?.validated
         let banner = Banner(title: title, subtitle: subtitle, image: image, backgroundColor: color)
         banner.springiness = currentSpringiness()
         banner.position = currentPosition()
-        if inViewSwitch.on {
+        if inViewSwitch.isOn {
             banner.show(view, duration: 3.0)
         } else {
             banner.show(duration: 3.0)
@@ -42,16 +42,16 @@ class ViewController: UIViewController {
     
     func currentPosition() -> BannerPosition {
         switch positionSegmentedControl.selectedSegmentIndex {
-        case 0: return .Top
-        default: return .Bottom
+        case 0: return .top
+        default: return .bottom
         }
     }
     
     func currentSpringiness() -> BannerSpringiness {
         switch springinessSegmentedControl.selectedSegmentIndex {
-        case 0: return .None
-        case 1: return .Slight
-        default: return .Heavy
+        case 0: return .none
+        case 1: return .slight
+        default: return .heavy
         }
     }
     

--- a/Example/BRYXBannerExample.xcodeproj/project.pbxproj
+++ b/Example/BRYXBannerExample.xcodeproj/project.pbxproj
@@ -129,6 +129,7 @@
 				TargetAttributes = {
 					DCEB2C281C3F3041003BAF35 = {
 						CreatedOnToolsVersion = 7.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -316,6 +317,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bryx.BRYXBanner;
 				PRODUCT_NAME = BRYXBannerExample;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -328,6 +330,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = com.bryx.BRYXBanner;
 				PRODUCT_NAME = BRYXBannerExample;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -295,6 +295,9 @@
 					75AEEEFD7E431013E8E60009251D5797 = {
 						LastSwiftMigration = 0800;
 					};
+					CD81CAE478667BB7668A79FA31DDE93D = {
+						LastSwiftMigration = 0800;
+					};
 					E45C60E65DC7B25E659C0A735F907FC7 = {
 						LastSwiftMigration = 0800;
 					};
@@ -408,6 +411,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -555,6 +559,7 @@
 				PRODUCT_NAME = Pods_BRYXBannerExample;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -295,6 +295,9 @@
 					75AEEEFD7E431013E8E60009251D5797 = {
 						LastSwiftMigration = 0800;
 					};
+					E45C60E65DC7B25E659C0A735F907FC7 = {
+						LastSwiftMigration = 0800;
+					};
 				};
 			};
 			buildConfigurationList = 2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */;
@@ -422,6 +425,7 @@
 				PRODUCT_NAME = BRYXBanner;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Debug;
@@ -568,6 +572,7 @@
 				PRODUCT_NAME = BRYXBanner;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 				WRAPPER_EXTENSION = bundle;
 			};
 			name = Release;

--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -208,8 +208,8 @@ open class Banner: UIView {
     }
     
     private func addGestureRecognizers() {
-      addGestureRecognizer(UITapGestureRecognizer(target: self, action:  #selector(Banner.didTap(_:))))
-      let swipe = UISwipeGestureRecognizer(target: self, action: #selector(Banner.didSwipe(_:)))
+        addGestureRecognizer(UITapGestureRecognizer(target: self, action:  #selector(Banner.didTap(_:))))
+        let swipe = UISwipeGestureRecognizer(target: self, action: #selector(Banner.didSwipe(_:)))
         swipe.direction = .up
         addGestureRecognizer(swipe)
     }

--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -342,7 +342,7 @@ open class Banner: UIView {
             self.bannerState = .showing
             }, completion: { finished in
                 guard let duration = duration else { return }
-                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(duration * TimeInterval(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)) {
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + DispatchTimeInterval.milliseconds(Int(1000.0 * duration))) {
                     self.dismiss(self.adjustsStatusBarStyle ? oldStatusBarStyle : nil)
                 }
         })

--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -26,7 +26,7 @@ public enum BannerPosition {
 /// - Heavy: The banner will bounce a lot.
 public enum BannerSpringiness {
     case none, slight, heavy
-    private var springValues: (damping: CGFloat, velocity: CGFloat) {
+    fileprivate var springValues: (damping: CGFloat, velocity: CGFloat) {
         switch self {
         case .none: return (damping: 1.0, velocity: 1.0)
         case .slight: return (damping: 0.7, velocity: 1.5)
@@ -36,9 +36,9 @@ public enum BannerSpringiness {
 }
 
 /// Banner is a dropdown notification view that presents above the main view controller, but below the status bar.
-public class Banner: UIView {
+open class Banner: UIView {
     class func topWindow() -> UIWindow? {
-        for window in UIApplication.shared().windows.reversed() {
+        for window in UIApplication.shared.windows.reversed() {
             if window.windowLevel == UIWindowLevelNormal && !window.isHidden && window.frame != CGRect.zero { return window }
         }
         return nil
@@ -49,80 +49,80 @@ public class Banner: UIView {
     private let backgroundView = UIView()
     
     /// How long the slide down animation should last.
-    public var animationDuration: TimeInterval = 0.4
+    open var animationDuration: TimeInterval = 0.4
     
     /// The preferred style of the status bar during display of the banner. Defaults to `.LightContent`.
     ///
     /// If the banner's `adjustsStatusBarStyle` is false, this property does nothing.
-    public var preferredStatusBarStyle = UIStatusBarStyle.lightContent
+    open var preferredStatusBarStyle = UIStatusBarStyle.lightContent
     
     /// Whether or not this banner should adjust the status bar style during its presentation. Defaults to `false`.
-    public var adjustsStatusBarStyle = false
+    open var adjustsStatusBarStyle = false
     
     /// Wheter the banner should appear at the top or the bottom of the screen. Defaults to `.Top`.
-    public var position = BannerPosition.top
+    open var position = BannerPosition.top
 
     /// How 'springy' the banner should display. Defaults to `.Slight`
-    public var springiness = BannerSpringiness.slight
+    open var springiness = BannerSpringiness.slight
     
     /// The color of the text as well as the image tint color if `shouldTintImage` is `true`.
-    public var textColor = UIColor.white() {
+    open var textColor = UIColor.white {
         didSet {
             resetTintColor()
         }
     }
     
     /// Whether or not the banner should show a shadow when presented.
-    public var hasShadows = true {
+    open var hasShadows = true {
         didSet {
             resetShadows()
         }
     }
     
     /// The color of the background view. Defaults to `nil`.
-    override public var backgroundColor: UIColor? {
+    override open var backgroundColor: UIColor? {
         get { return backgroundView.backgroundColor }
         set { backgroundView.backgroundColor = newValue }
     }
     
     /// The opacity of the background view. Defaults to 0.95.
-    override public var alpha: CGFloat {
+    override open var alpha: CGFloat {
         get { return backgroundView.alpha }
         set { backgroundView.alpha = newValue }
     }
     
     /// A block to call when the uer taps on the banner.
-    public var didTapBlock: (() -> ())?
+    open var didTapBlock: (() -> ())?
     
     /// A block to call after the banner has finished dismissing and is off screen.
-    public var didDismissBlock: (() -> ())?
+    open var didDismissBlock: (() -> ())?
     
     /// Whether or not the banner should dismiss itself when the user taps. Defaults to `true`.
-    public var dismissesOnTap = true
+    open var dismissesOnTap = true
     
     /// Whether or not the banner should dismiss itself when the user swipes up. Defaults to `true`.
-    public var dismissesOnSwipe = true
+    open var dismissesOnSwipe = true
     
     /// Whether or not the banner should tint the associated image to the provided `textColor`. Defaults to `true`.
-    public var shouldTintImage = true {
+    open var shouldTintImage = true {
         didSet {
             resetTintColor()
         }
     }
     
     /// The label that displays the banner's title.
-    public let titleLabel: UILabel = {
+    open let titleLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyleHeadline)
+        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.headline)
         label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
         }()
     
     /// The label that displays the banner's subtitle.
-    public let detailLabel: UILabel = {
+    open let detailLabel: UILabel = {
         let label = UILabel()
-        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyleSubheadline)
+        label.font = UIFont.preferredFont(forTextStyle: UIFontTextStyle.subheadline)
         label.numberOfLines = 0
         label.translatesAutoresizingMaskIntoConstraints = false
         return label
@@ -132,7 +132,7 @@ public class Banner: UIView {
     let image: UIImage?
     
     /// The image view that displays the `image`.
-    public let imageView: UIImageView = {
+    open let imageView: UIImageView = {
         let imageView = UIImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.contentMode = .scaleAspectFit
@@ -154,7 +154,7 @@ public class Banner: UIView {
     /// - parameter image: The image on the left of the banner. Optional. Defaults to nil.
     /// - parameter backgroundColor: The color of the banner's background view. Defaults to `UIColor.blackColor()`.
     /// - parameter didTapBlock: An action to be called when the user taps on the banner. Optional. Defaults to `nil`.
-    public required init(title: String? = nil, subtitle: String? = nil, image: UIImage? = nil, backgroundColor: UIColor = UIColor.black(), didTapBlock: (() -> ())? = nil) {
+    public required init(title: String? = nil, subtitle: String? = nil, image: UIImage? = nil, backgroundColor: UIColor = UIColor.black, didTapBlock: (() -> ())? = nil) {
         self.didTapBlock = didTapBlock
         self.image = image
         super.init(frame: CGRect.zero)
@@ -169,7 +169,7 @@ public class Banner: UIView {
     }
     
     private func forceUpdates() {
-        guard let superview = superview, showingConstraint = showingConstraint, hiddenConstraint = hiddenConstraint else { return }
+      guard let superview = superview, let showingConstraint = showingConstraint, let hiddenConstraint = hiddenConstraint else { return }
         switch bannerState {
         case .hidden:
             superview.removeConstraint(showingConstraint)
@@ -202,8 +202,8 @@ public class Banner: UIView {
     }
     
     private func addGestureRecognizers() {
-        addGestureRecognizer(UITapGestureRecognizer(target: self, action: "didTap:"))
-        let swipe = UISwipeGestureRecognizer(target: self, action: "didSwipe:")
+      addGestureRecognizer(UITapGestureRecognizer(target: self, action:  #selector(Banner.didTap(_:))))
+      let swipe = UISwipeGestureRecognizer(target: self, action: #selector(Banner.didSwipe(_:)))
         swipe.direction = .up
         addGestureRecognizer(swipe)
     }
@@ -216,7 +216,7 @@ public class Banner: UIView {
     }
     
     private func resetShadows() {
-        layer.shadowColor = UIColor.black().cgColor
+        layer.shadowColor = UIColor.black.cgColor
         layer.shadowOpacity = self.hasShadows ? 0.5 : 0.0
         layer.shadowOffset = CGSize(width: 0, height: 0)
         layer.shadowRadius = 4
@@ -281,9 +281,9 @@ public class Banner: UIView {
     private var hiddenConstraint: NSLayoutConstraint?
     private var commonConstraints = [NSLayoutConstraint]()
     
-    override public func didMoveToSuperview() {
+    override open func didMoveToSuperview() {
         super.didMoveToSuperview()
-        guard let superview = superview where bannerState != .gone else { return }
+        guard let superview = superview, bannerState != .gone else { return }
         commonConstraints = self.constraintsWithAttributes([.leading, .trailing], .equal, to: superview)
         superview.addConstraints(commonConstraints)
 
@@ -299,7 +299,7 @@ public class Banner: UIView {
         }
     }
   
-    public override func layoutSubviews() {
+    open override func layoutSubviews() {
       super.layoutSubviews()
       adjustHeightOffset()
       layoutIfNeeded()
@@ -308,7 +308,7 @@ public class Banner: UIView {
     private func adjustHeightOffset() {
       guard let superview = superview else { return }
       if superview === Banner.topWindow() && self.position == .top {
-        let statusBarSize = UIApplication.shared().statusBarFrame.size
+        let statusBarSize = UIApplication.shared.statusBarFrame.size
         let heightOffset = min(statusBarSize.height, statusBarSize.width) // Arbitrary, but looks nice.
         contentTopOffsetConstraint.constant = heightOffset
         minimumHeightConstraint.constant = statusBarSize.height > 0 ? 80 : 40
@@ -320,7 +320,7 @@ public class Banner: UIView {
   
     /// Shows the banner. If a view is specified, the banner will be displayed at the top of that view, otherwise at top of the top window. If a `duration` is specified, the banner dismisses itself automatically after that duration elapses.
     /// - parameter view: A view the banner will be shown in. Optional. Defaults to 'nil', which in turn means it will be shown in the top window. duration A time interval, after which the banner will dismiss itself. Optional. Defaults to `nil`.
-    public func show(_ view: UIView? = Banner.topWindow(), duration: TimeInterval? = nil) {
+    open func show(_ view: UIView? = Banner.topWindow(), duration: TimeInterval? = nil) {
         guard let view = view else {
             print("[Banner]: Could not find view. Aborting.")
             return
@@ -328,27 +328,27 @@ public class Banner: UIView {
         view.addSubview(self)
         forceUpdates()
         let (damping, velocity) = self.springiness.springValues
-        let oldStatusBarStyle = UIApplication.shared().statusBarStyle
+        let oldStatusBarStyle = UIApplication.shared.statusBarStyle
         if adjustsStatusBarStyle {
-          UIApplication.shared().setStatusBarStyle(preferredStatusBarStyle, animated: true)
+          UIApplication.shared.setStatusBarStyle(preferredStatusBarStyle, animated: true)
         }
         UIView.animate(withDuration: animationDuration, delay: 0.0, usingSpringWithDamping: damping, initialSpringVelocity: velocity, options: .allowUserInteraction, animations: {
             self.bannerState = .showing
             }, completion: { finished in
                 guard let duration = duration else { return }
-                DispatchQueue.main.after(when: DispatchTime.now() + Double(Int64(duration * TimeInterval(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)) {
+                DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + Double(Int64(duration * TimeInterval(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)) {
                     self.dismiss(self.adjustsStatusBarStyle ? oldStatusBarStyle : nil)
                 }
         })
     }
   
     /// Dismisses the banner.
-    public func dismiss(_ oldStatusBarStyle: UIStatusBarStyle? = nil) {
+    open func dismiss(_ oldStatusBarStyle: UIStatusBarStyle? = nil) {
         let (damping, velocity) = self.springiness.springValues
         UIView.animate(withDuration: animationDuration, delay: 0.0, usingSpringWithDamping: damping, initialSpringVelocity: velocity, options: .allowUserInteraction, animations: {
             self.bannerState = .hidden
             if let oldStatusBarStyle = oldStatusBarStyle {
-                UIApplication.shared().setStatusBarStyle(oldStatusBarStyle, animated: true)
+                UIApplication.shared.setStatusBarStyle(oldStatusBarStyle, animated: true)
             }
             }, completion: { finished in
                 self.bannerState = .gone
@@ -365,7 +365,7 @@ extension NSLayoutConstraint {
 }
 
 extension UIView {
-    func constraintsEqualToSuperview(_ edgeInsets: UIEdgeInsets = UIEdgeInsetsZero) -> [NSLayoutConstraint] {
+    func constraintsEqualToSuperview(_ edgeInsets: UIEdgeInsets = UIEdgeInsets.zero) -> [NSLayoutConstraint] {
         self.translatesAutoresizingMaskIntoConstraints = false
         var constraints = [NSLayoutConstraint]()
         if let superview = self.superview {

--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -184,6 +184,7 @@ open class Banner: UIView {
         }
         setNeedsLayout()
         setNeedsUpdateConstraints()
+        // Managing different -layoutIfNeeded behaviours among iOS versions (for more, read the UIKit iOS 10 release notes)
         if #available(iOS 10.0, *) {
             superview.layoutIfNeeded()
         } else {

--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -184,6 +184,11 @@ open class Banner: UIView {
         }
         setNeedsLayout()
         setNeedsUpdateConstraints()
+        if #available(iOS 10.0, *) {
+            superview.layoutIfNeeded()
+        } else {
+            layoutIfNeeded()
+        }
         layoutIfNeeded()
         updateConstraintsIfNeeded()
     }

--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -190,7 +190,6 @@ open class Banner: UIView {
         } else {
             layoutIfNeeded()
         }
-        layoutIfNeeded()
         updateConstraintsIfNeeded()
     }
   


### PR DESCRIPTION
Hi guys, the title says it all.

I've described the animation problem in https://github.com/bryx-inc/BRYXBanner/issues/51 , today I've found a bit of time and fixed it.

The problem originates from a `-layoutIfNeeded` incorrect behaviour on iOS 9.

I've found out about this by reading the [Release Notes of iOS 10 Beta 6](https://developer.apple.com/go/?id=ios-10.0-sdk-rn).

For your convenience, here's the interesting part (Under _UIKit Notes and Known Issues_):

---

Sending `-layoutIfNeeded` to a view is not expected to move the view, but in earlier releases, if the view had `translatesAutoresizingMaskIntoConstraints == false`, and if it was
being positioned by constraints, `-layoutIfNeeded` would move the view to match the layout
engine before sending layout to the subtree.

These changes correct this behavior, and the receiver’s position and usually its size won’t be
affected by `-layoutIfNeeded`.

Some existing code may be relying on this incorrect behavior that is now corrected. There is no
behavior change for binaries linked before iOS 10, but when building on iOS 10 you may need to
correct some situations by sending `-layoutIfNeeded` to a superview of the
`translatesAutoresizingMaskIntoConstraints == false` view that was the previous
receiver, or else positioning and sizing it before (or after, depending on your desired behavior) `-layoutIfNeeded`.

---

Cheers!
