### PR TITLE
Added support for apps with multiple UIWIndows

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -39,7 +39,7 @@ public enum BannerSpringiness {
 open class Banner: UIView {
     class func topWindow() -> UIWindow? {
         for window in UIApplication.shared.windows.reversed() {
-            if window.windowLevel == UIWindowLevelNormal && !window.isHidden && window.frame != CGRect.zero { return window }
+            if window.windowLevel == UIWindowLevelNormal && window.isKeyWindow && window.frame != CGRect.zero { return window }
         }
         return nil
     }


### PR DESCRIPTION
In case that an app has more than one UIWindow with windowLevel equal to UIWindowLevelNormal, Banner.topWindow() function won’t find the right one.

Signed-off-by: Pablo Romero <promero@carecloud.com>