### PR TITLE
Resolves issue #24 - Wrong width

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -293,7 +293,7 @@ open class Banner: UIView {
     override open func didMoveToSuperview() {
         super.didMoveToSuperview()
         guard let superview = superview, bannerState != .gone else { return }
-        commonConstraints = self.constraintsWithAttributes([.leading, .trailing], .equal, to: superview)
+        commonConstraints = self.constraintsWithAttributes([.width], .equal, to: superview)
         superview.addConstraints(commonConstraints)
 
         switch self.position {


### PR DESCRIPTION
Instead of using leading and trailing constraints to the superview,
specify that the widths should be equal.  With this change, the
width of the notification will match that of the table view.