### PR TITLE
add spacing for bottom banners on iPhone X models

### DIFF
--- a/Pod/Classes/Banner.swift
+++ b/Pod/Classes/Banner.swift
@@ -232,6 +232,7 @@ open class Banner: UIView {
     }
   
     private var contentTopOffsetConstraint: NSLayoutConstraint!
+    private var contentBottomOffsetConstraint: NSLayoutConstraint!
     private var minimumHeightConstraint: NSLayoutConstraint!
   
     private func initializeSubviews() {
@@ -255,9 +256,10 @@ open class Banner: UIView {
         labelView.addSubview(titleLabel)
         labelView.addSubview(detailLabel)
         backgroundView.addConstraints(NSLayoutConstraint.defaultConstraintsWithVisualFormat("H:|[contentView]|", views: views))
-        backgroundView.addConstraint(contentView.constraintWithAttribute(.bottom, .equal, to: .bottom, of: backgroundView))
         contentTopOffsetConstraint = contentView.constraintWithAttribute(.top, .equal, to: .top, of: backgroundView)
+        contentBottomOffsetConstraint = contentView.constraintWithAttribute(.bottom, .equal, to: .bottom, of: backgroundView)
         backgroundView.addConstraint(contentTopOffsetConstraint)
+        backgroundView.addConstraint(contentBottomOffsetConstraint)
         let leftConstraintText: String
         if image == nil {
             leftConstraintText = "|"
@@ -320,9 +322,15 @@ open class Banner: UIView {
         let statusBarSize = UIApplication.shared.statusBarFrame.size
         let heightOffset = min(statusBarSize.height, statusBarSize.width) // Arbitrary, but looks nice.
         contentTopOffsetConstraint.constant = heightOffset
+        contentBottomOffsetConstraint.constant = 0
         minimumHeightConstraint.constant = statusBarSize.height > 0 ? minimumHeight : 40
       } else {
+        var bottomSpacing: CGFloat = 0
+        if #available(iOS 11.0, *) {
+            bottomSpacing = safeAreaInsets.bottom // handle the safe area for iPhone X models
+        }
         contentTopOffsetConstraint.constant = 0
+        contentBottomOffsetConstraint.constant = -bottomSpacing
         minimumHeightConstraint.constant = 0
       }
     }


### PR DESCRIPTION
Adds some bottom spacing to support safe area (mainly for iPhone X models)
Fixes: https://github.com/bryx-inc/BRYXBanner/issues/99

![iPhoneXr](https://user-images.githubusercontent.com/5355231/58998424-4efd2c80-87c6-11e9-93b1-4ac28008a26f.png)
