### PR TITLE
Adds support to Xcode 14

### DIFF
--- a/BRYXBanner.podspec
+++ b/BRYXBanner.podspec
@@ -7,7 +7,7 @@ Pod::Spec.new do |s|
   s.author           = { "Harlan Haskins" => "harlan@harlanhaskins.com" }
   s.source           = { :git => "https://github.com/bryx-inc/BRYXBanner.git", :tag => s.version.to_s }
 
-  s.platform     = :ios, '8.0'
+  s.platform     = :ios, '11.0'
   s.requires_arc = true
 
   s.swift_version = '5.0'


### PR DESCRIPTION
Changes the platform to iOS 11.0 since Xcode 14 only supports building for a deployment target of iOS 11.